### PR TITLE
Force pylablib version to 1.4.1

### DIFF
--- a/plugin_info.toml
+++ b/plugin_info.toml
@@ -11,7 +11,7 @@ license = 'MIT'
 
 [plugin-install]
 #packages required for your plugin:
-packages-required = ["pythonnet", "pywin32", "nicelib", "instrumental-lib", "pylablib", 'pymodaq>=4.0',
+packages-required = ["pythonnet", "pywin32", "nicelib", "instrumental-lib", "pylablib==1.4.1", 'pymodaq>=4.0',
     'opencv-python']
 
 [features]  # defines the plugin features contained into this plugin


### PR DESCRIPTION
Hi,
We've found out that the last pylablib version (1.4.2) throws a bug at initialization of Thorlabs TSI cameras. So I'd like to stay with 1.4.1 for now - is that ok with the color features you added?
