### PR TITLE
Add Kinesis KCube support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Authors
 * Amelie DeShazer (adeshazer@wisc.edu)
 * Astha Khandelwal (asthak@iisc.ac.in)
 * Daichi Kozawa (kozawa.daichi@nims.go.jp)
+* Arnaud Meyer (arnaud.meyer@univ-st-etienne.fr)
 
 Instruments
 ===========
@@ -43,6 +44,7 @@ Actuators
 * **BrushlessDCMotor**: Kinesis control of DC Brushless Motor (tested with the BBD201 controller)
 * **Kinesis_KPZ101**: Piezo Electric Stage Kinesis series (KPZ101)
 * **DCServoTCube**: DC Servo motors controlled using a TCube (tested with TDC001 and MTS50 motor)
+* **DCServoKCube**: DC Servo motors controlled using a KCube (tested with KDC101)
 
 Viewer0D
 ++++++++

--- a/src/pymodaq_plugins_thorlabs/daq_move_plugins/daq_move_DCServoKCube.py
+++ b/src/pymodaq_plugins_thorlabs/daq_move_plugins/daq_move_DCServoKCube.py
@@ -1,0 +1,156 @@
+from pymodaq.control_modules.move_utility_classes import (
+    DAQ_Move_base, comon_parameters_fun, main, DataActuatorType, DataActuator)
+from pymodaq.utils.daq_utils import ThreadCommand
+
+from pymodaq.utils.parameter import Parameter
+
+from pymodaq_plugins_thorlabs.hardware.kinesis import DCServoKCube, serialnumbers_kcube_dcservo
+from pymodaq.utils.logger import set_logger, get_module_name
+
+logger = set_logger(get_module_name(__file__))
+
+
+class DAQ_Move_DCServoKCube(DAQ_Move_base):
+    """ Instrument plugin class for an actuator.
+
+    This object inherits all functionalities to communicate with PyMoDAQ’s DAQ_Move module through inheritance via
+    DAQ_Move_base. It makes a bridge between the DAQ_Move module and the Python wrapper of a particular instrument.
+
+    Attributes:
+    -----------
+    controller: object
+        The particular object that allow the communication with the hardware, in general a python wrapper around the
+         hardware library.
+
+    """
+    _controller_units = DCServoKCube.default_units
+    is_multiaxes = False
+    _axes_names = ['']
+    _epsilon = 0.005
+    data_actuator_type = DataActuatorType.DataActuator
+    params = [
+                 {'title': 'Serial Number:', 'name': 'serial_number', 'type': 'list',
+                  'limits': serialnumbers_kcube_dcservo, 'value': serialnumbers_kcube_dcservo[0]}
+
+             ] + comon_parameters_fun(is_multiaxes, axes_names=_axes_names, epsilon=_epsilon)
+
+    def ini_attributes(self):
+        self.controller: DCServoKCube = None
+        self._move_done = False
+
+    def move_done_callback(self, val: int):
+        """ will be triggered for each end of move: abs, rel or homing"""
+        self._move_done = True
+        self.stop_motion()
+        logger.debug('Callback called')
+
+    def user_condition_to_reach_target(self) -> bool:
+        """ Implement a condition for exiting the polling mechanism and specifying that the
+        target value has been reached
+
+       Returns
+        -------
+        bool: if True, PyMoDAQ considers the target value has been reached
+        """
+
+        return self._move_done
+
+    def get_actuator_value(self):
+        """Get the current value from the hardware with scaling conversion.
+
+        Returns
+        -------
+        float: The position obtained after scaling conversion.
+        """
+        pos = DataActuator(
+            data=self.controller.get_position(),
+            units=self.controller.get_units()
+        )
+        pos = self.get_position_with_scaling(pos)
+        return pos
+
+    def close(self):
+        """Terminate the communication protocol"""
+        if self.is_master:
+            self.controller.close()
+
+    def commit_settings(self, param: Parameter):
+        """Apply the consequences of a change of value in the detector settings
+
+        Parameters
+        ----------
+        param: Parameter
+            A given parameter (within detector_settings) whose value has been changed by the user
+        """
+        pass
+
+    def ini_stage(self, controller=None):
+        """Actuator communication initialization
+
+        Parameters
+        ----------
+        controller: (object)
+            custom object of a PyMoDAQ plugin (Slave case). None if only one actuator by controller (Master case)
+
+        Returns
+        -------
+        info: str
+        initialized: bool
+            False if initialization failed otherwise True
+        """
+
+        if self.is_master:
+            self.controller = DCServoKCube()
+            self.controller.connect(self.settings['serial_number'])
+        else:
+            self.controller = controller
+
+        # update the axis unit by interogating the controller and the specific axis
+        self.axis_unit = self.controller.get_units()
+
+        if not self.controller.is_homed:
+            self.move_home()
+
+        info = f'{self.controller.name} - {self.controller.serial_number}'
+        initialized = True
+        return info, initialized
+
+    def move_abs(self, value: DataActuator):
+        """ Move the actuator to the absolute target defined by value
+
+        Parameters
+        ----------
+        value: (float) value of the absolute target positioning
+        """
+        self._move_done = False
+        value = self.check_bound(value)
+        self.target_value = value
+        value = self.set_position_with_scaling(value)  # apply scaling if the user specified one
+        self.controller.move_abs(value.value(), callback=self.move_done_callback)
+
+    def move_rel(self, value: DataActuator):
+        """ Move the actuator to the relative target actuator value defined by value
+
+        Parameters
+        ----------
+        value: (float) value of the relative target positioning
+        """
+        self._move_done = False
+        value = self.check_bound(self.current_position + value) - self.current_position
+        self.target_value = value + self.current_position
+        value = self.set_position_relative_with_scaling(value)
+        self.controller.move_rel(value.value(), callback=self.move_done_callback)
+
+    def move_home(self):
+        """Call the reference method of the controller"""
+        self._move_done = False
+        self.controller.home(callback=self.move_done_callback)
+
+    def stop_motion(self):
+        """Stop the actuator and emits move_done signal"""
+
+        self.controller.stop()
+
+
+if __name__ == '__main__':
+    main(__file__, init=False)

--- a/src/pymodaq_plugins_thorlabs/daq_move_plugins/daq_move_DCServoKCube.py
+++ b/src/pymodaq_plugins_thorlabs/daq_move_plugins/daq_move_DCServoKCube.py
@@ -1,20 +1,16 @@
 from pymodaq.control_modules.move_utility_classes import (
     DAQ_Move_base, comon_parameters_fun, main, DataActuatorType, DataActuator)
-from pymodaq.utils.daq_utils import ThreadCommand
 
-from pymodaq.utils.parameter import Parameter
-
+from pymodaq_plugins_thorlabs.daq_move_plugins.daq_move_DCServoTCube import DAQ_Move_DCServoTCube
 from pymodaq_plugins_thorlabs.hardware.kinesis import DCServoKCube, serialnumbers_kcube_dcservo
-from pymodaq.utils.logger import set_logger, get_module_name
 
+from pymodaq.utils.logger import set_logger, get_module_name
 logger = set_logger(get_module_name(__file__))
 
 
-class DAQ_Move_DCServoKCube(DAQ_Move_base):
-    """ Instrument plugin class for an actuator.
-
-    This object inherits all functionalities to communicate with PyMoDAQ’s DAQ_Move module through inheritance via
-    DAQ_Move_base. It makes a bridge between the DAQ_Move module and the Python wrapper of a particular instrument.
+class DAQ_Move_DCServoKCube(DAQ_Move_DCServoTCube):
+    """ Instrument plugin class for Kinesis KCube devices.
+    All functionality is adapted from DAQ_Move_DCServoTCube. 
 
     Attributes:
     -----------
@@ -24,65 +20,19 @@ class DAQ_Move_DCServoKCube(DAQ_Move_base):
 
     """
     _controller_units = DCServoKCube.default_units
-    is_multiaxes = False
-    _axes_names = ['']
-    _epsilon = 0.005
-    data_actuator_type = DataActuatorType.DataActuator
     params = [
                  {'title': 'Serial Number:', 'name': 'serial_number', 'type': 'list',
                   'limits': serialnumbers_kcube_dcservo, 'value': serialnumbers_kcube_dcservo[0]}
 
-             ] + comon_parameters_fun(is_multiaxes, axes_names=_axes_names, epsilon=_epsilon)
+             ] + comon_parameters_fun(DAQ_Move_DCServoTCube.is_multiaxes,
+                                      axes_names=DAQ_Move_DCServoTCube._axes_names,
+                                      epsilon=DAQ_Move_DCServoTCube._epsilon)
+
 
     def ini_attributes(self):
         self.controller: DCServoKCube = None
         self._move_done = False
 
-    def move_done_callback(self, val: int):
-        """ will be triggered for each end of move: abs, rel or homing"""
-        self._move_done = True
-        self.stop_motion()
-        logger.debug('Callback called')
-
-    def user_condition_to_reach_target(self) -> bool:
-        """ Implement a condition for exiting the polling mechanism and specifying that the
-        target value has been reached
-
-       Returns
-        -------
-        bool: if True, PyMoDAQ considers the target value has been reached
-        """
-
-        return self._move_done
-
-    def get_actuator_value(self):
-        """Get the current value from the hardware with scaling conversion.
-
-        Returns
-        -------
-        float: The position obtained after scaling conversion.
-        """
-        pos = DataActuator(
-            data=self.controller.get_position(),
-            units=self.controller.get_units()
-        )
-        pos = self.get_position_with_scaling(pos)
-        return pos
-
-    def close(self):
-        """Terminate the communication protocol"""
-        if self.is_master:
-            self.controller.close()
-
-    def commit_settings(self, param: Parameter):
-        """Apply the consequences of a change of value in the detector settings
-
-        Parameters
-        ----------
-        param: Parameter
-            A given parameter (within detector_settings) whose value has been changed by the user
-        """
-        pass
 
     def ini_stage(self, controller=None):
         """Actuator communication initialization
@@ -114,42 +64,6 @@ class DAQ_Move_DCServoKCube(DAQ_Move_base):
         info = f'{self.controller.name} - {self.controller.serial_number}'
         initialized = True
         return info, initialized
-
-    def move_abs(self, value: DataActuator):
-        """ Move the actuator to the absolute target defined by value
-
-        Parameters
-        ----------
-        value: (float) value of the absolute target positioning
-        """
-        self._move_done = False
-        value = self.check_bound(value)
-        self.target_value = value
-        value = self.set_position_with_scaling(value)  # apply scaling if the user specified one
-        self.controller.move_abs(value.value(), callback=self.move_done_callback)
-
-    def move_rel(self, value: DataActuator):
-        """ Move the actuator to the relative target actuator value defined by value
-
-        Parameters
-        ----------
-        value: (float) value of the relative target positioning
-        """
-        self._move_done = False
-        value = self.check_bound(self.current_position + value) - self.current_position
-        self.target_value = value + self.current_position
-        value = self.set_position_relative_with_scaling(value)
-        self.controller.move_rel(value.value(), callback=self.move_done_callback)
-
-    def move_home(self):
-        """Call the reference method of the controller"""
-        self._move_done = False
-        self.controller.home(callback=self.move_done_callback)
-
-    def stop_motion(self):
-        """Stop the actuator and emits move_done signal"""
-
-        self.controller.stop()
 
 
 if __name__ == '__main__':

--- a/src/pymodaq_plugins_thorlabs/hardware/kinesis.py
+++ b/src/pymodaq_plugins_thorlabs/hardware/kinesis.py
@@ -30,16 +30,17 @@ import Thorlabs.MotionControl.Benchtop.BrushlessMotorCLI as BrushlessMotorCLI
 import Thorlabs.MotionControl.KCube.PiezoCLI as KCubePiezo
 import Thorlabs.MotionControl.TCube.DCServoCLI as TCubeDCServo
 
-Device.DeviceManagerCLI.BuildDeviceList()
-serialnumbers_integrated_stepper = [str(ser) for ser in
-                                    Device.DeviceManagerCLI.GetDeviceList(Integrated.CageRotator.DevicePrefix)]
-serialnumbers_flipper = [str(ser) for ser in
-                         Device.DeviceManagerCLI.GetDeviceList(FilterFlipper.FilterFlipper.DevicePrefix)]
-serialnumbers_brushless = [str(ser) for ser in
-                           Device.DeviceManagerCLI.GetDeviceList(BrushlessMotorCLI.BenchtopBrushlessMotor.DevicePrefix)]
-serialnumbers_piezo = [str(ser) for ser in Device.DeviceManagerCLI.GetDeviceList(KCubePiezo.KCubePiezo.DevicePrefix)]
 
-serialnumbers_tcube_dcservo = [str(ser) for ser in Device.DeviceManagerCLI.GetDeviceList(TCubeDCServo.TCubeDCServo.DevicePrefix)]
+# First, build device list
+Device.DeviceManagerCLI.BuildDeviceList()
+
+# Then, get serial numbers for each category
+_sn_list = lambda prefix: [str(sn) for sn in Device.DeviceManagerCLI.GetDeviceList(prefix)]
+serialnumbers_integrated_stepper = _sn_list(Integrated.CageRotator.DevicePrefix)
+serialnumbers_flipper = _sn_list(FilterFlipper.FilterFlipper.DevicePrefix)
+serialnumbers_brushless = _sn_list(BrushlessMotorCLI.BenchtopBrushlessMotor.DevicePrefix)
+serialnumbers_piezo = _sn_list(KCubePiezo.KCubePiezo.DevicePrefix)
+serialnumbers_tcube_dcservo = _sn_list(TCubeDCServo.TCubeDCServo.DevicePrefix)
 
 
 class Kinesis:

--- a/src/pymodaq_plugins_thorlabs/hardware/kinesis.py
+++ b/src/pymodaq_plugins_thorlabs/hardware/kinesis.py
@@ -21,6 +21,7 @@ clr.AddReference("Thorlabs.MotionControl.FilterFlipperCLI")
 clr.AddReference("Thorlabs.MotionControl.Benchtop.BrushlessMotorCLI")
 clr.AddReference("Thorlabs.MotionControl.KCube.PiezoCLI")
 clr.AddReference("Thorlabs.MotionControl.TCube.DCServoCLI ")
+clr.AddReference("Thorlabs.MotionControl.KCube.DCServoCLI ")
 
 import Thorlabs.MotionControl.FilterFlipperCLI as FilterFlipper
 import Thorlabs.MotionControl.IntegratedStepperMotorsCLI as Integrated
@@ -29,6 +30,7 @@ import Thorlabs.MotionControl.GenericMotorCLI as Generic
 import Thorlabs.MotionControl.Benchtop.BrushlessMotorCLI as BrushlessMotorCLI
 import Thorlabs.MotionControl.KCube.PiezoCLI as KCubePiezo
 import Thorlabs.MotionControl.TCube.DCServoCLI as TCubeDCServo
+import Thorlabs.MotionControl.KCube.DCServoCLI as KCubeDCServo
 
 
 # First, build device list
@@ -41,6 +43,7 @@ serialnumbers_flipper = _sn_list(FilterFlipper.FilterFlipper.DevicePrefix)
 serialnumbers_brushless = _sn_list(BrushlessMotorCLI.BenchtopBrushlessMotor.DevicePrefix)
 serialnumbers_piezo = _sn_list(KCubePiezo.KCubePiezo.DevicePrefix)
 serialnumbers_tcube_dcservo = _sn_list(TCubeDCServo.TCubeDCServo.DevicePrefix)
+serialnumbers_kcube_dcservo = _sn_list(KCubeDCServo.KCubeDCServo.DevicePrefix)
 
 
 class Kinesis:
@@ -354,6 +357,28 @@ class DCServoTCube(Kinesis):
         return Decimal.ToDouble(self._device.get_DevicePosition())
 
 
+class DCServoKCube(Kinesis):
+    """ Specific Kinesis class for KCube controllers"""
+    n_channels = 1
+    default_units = 'mm'
+
+    def __init__(self):
+        super().__init__()
+        self._device: KCubeDCServo.KCubeDCServo = None
+
+    def connect(self, serial: int):
+        if serial in serialnumbers_kcube_dcservo:
+            self._device = (
+                KCubeDCServo.KCubeDCServo.CreateKCubeDCServo(serial))
+            super().connect(serial)
+            self._device.EnableDevice()
+            sleep(0.5)
+            self._device.LoadMotorConfiguration(serial)
+            self.motor_settings = self._device.MotorDeviceSettings
+
+
+    def get_position(self) -> float:
+        return Decimal.ToDouble(self._device.get_DevicePosition())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Quick-and-dirty support for Kinesis KCube devices (tested on KDC101). Addresses issue #38.

This is basically a copy of `DCServoTCube` with all `T` replaced by `K` (so maybe these two can be fused together someday).

It works on a KDC101 (homing / absolute / relative), however the value displayed on PyMoDAQ slightly differs from the one displayed on the hardware screen of the controller (ex: 5.0366 mm on hardware vs. 5.0000 mm in PyMoDAQ). It seems this issue still occurs when using the [example code supplied by Thorlabs](Python/KCube/KDC101/kdc101_pythonnet.py) so it may come from the supplier library itself.